### PR TITLE
Add View.dip() function.

### DIFF
--- a/dsl/static/src/common/Dimensions.kt
+++ b/dsl/static/src/common/Dimensions.kt
@@ -37,6 +37,8 @@ val MAXDPI: Int = 0xfffe
 //returns dip(dp) dimension value in pixels
 fun Context.dip(value: Int): Int = (value * (resources?.displayMetrics?.density ?: 0f)).toInt()
 fun Context.dip(value: Float): Int = (value * (resources?.displayMetrics?.density ?: 0f)).toInt()
+fun android.view.View.dip(value: Int): Int = (value * (resources?.displayMetrics?.density ?: 0f)).toInt()
+fun android.view.View.dip(value: Float): Int = (value * (resources?.displayMetrics?.density ?: 0f)).toInt()
 
 //return sp dimension value in pixels
 fun Context.sp(value: Int): Int = (value * (resources?.displayMetrics?.scaledDensity ?: 0f)).toInt()


### PR DESCRIPTION
When building the layout in a custom view class.
In order to be able to call `dip(30)` directly, without having to pass by the context. Currently we have to call `context.dip(30)` which is less pretty.

Related issue: #95 