### PR TITLE
Add Bintray Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Download](https://api.bintray.com/packages/jetbrains/anko/anko/images/download.svg) ](https://bintray.com/jetbrains/anko/anko/_latestVersion)
 Anko
 ===========
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Download](https://api.bintray.com/packages/jetbrains/anko/anko/images/download.svg) ](https://bintray.com/jetbrains/anko/anko/_latestVersion)
+![GitHub version](https://badge.fury.io/gh/Kotlin%2Fanko.svg)
 Anko
 ===========
 


### PR DESCRIPTION
For some reason, the badge always picks the first artifact, which is anko-design. If you know a way to fix it, I'm open for discussion.