### PR TITLE
Add Int.withAlpha to Helpers

### DIFF
--- a/dsl/static/src/common/Helpers.kt
+++ b/dsl/static/src/common/Helpers.kt
@@ -32,6 +32,10 @@ val Int.gray: Int
 val Int.opaque: Int
     get() = this or 0xff000000.toInt()
 
+fun Int.withAlpha(alpha: Int) {
+    require(alpha >= 0 && alpha <= 0xFF)
+    return this and 0x00FFFFFF or (alpha shl 24)
+}
 
 enum class ScreenSize {
     SMALL,


### PR DESCRIPTION
Returns `0x55FF0000` with `0xFF0000.withAlpha(0x55)`

Note: Sorry for the final line break, but I made this PR from Github and as [every file is composed of lines, which should all end with a line break](http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap03.html#tag_03_206), Github automatically added the missing line break, without my consent.