### PR TITLE
Few  corrections for SQLite static module

### DIFF
--- a/dsl/static/src/sqlite/SqlParsers.kt
+++ b/dsl/static/src/sqlite/SqlParsers.kt
@@ -135,7 +135,7 @@ inline fun <reified T: Any> classParser(): RowParser<T> {
     val clazz = T::class.java
     val constructors = clazz.declaredConstructors.filter {
         val types = it.parameterTypes
-        it.isAccessible && !it.isVarArgs && Modifier.isPublic(it.modifiers) &&
+        !it.isVarArgs && Modifier.isPublic(it.modifiers) &&
             types != null && types.size > 0
     }
     if (constructors.isEmpty())
@@ -160,7 +160,7 @@ inline fun <reified T: Any> classParser(): RowParser<T> {
 
     return object : RowParser<T> {
         override fun parseRow(columns: Array<Any>): T {
-            return c.newInstance(columns) as T
+            return c.newInstance(*columns) as T
         }
     }
 }


### PR DESCRIPTION
Remove [unnecessary ](http://stackoverflow.com/questions/18179593/why-a-public-constructor-is-not-accessible-via-reflection)isAccessible call. For constructor enough to be public.

Add special[ SPREAD operator ( * )](https://kotlinlang.org/docs/reference/java-interop.html#java-varargs) for call java method with Object... args