### PR TITLE
Fix doc/ADVANCED.md

### DIFF
--- a/doc/ADVANCED.md
+++ b/doc/ADVANCED.md
@@ -156,7 +156,7 @@ selector("Where are you from?", countries) { i ->
 There's a better way:
 
 ```kotlin
-async {
+async() {
     // Long background task
     uiThread {
         result.text = "Done"

--- a/doc/ADVANCED.md
+++ b/doc/ADVANCED.md
@@ -156,12 +156,12 @@ selector("Where are you from?", countries) { i ->
 There's a better way:
 
 ```kotlin
-async() {
+async({
     // Long background task
     uiThread {
         result.text = "Done"
     }
-}
+})
 ```
 
 You can even execute tasks using your own `ExecutorService`:


### PR DESCRIPTION
With Kotlin 1.0 beta4, `async` is reserved in front of `{` and `fun`.
So with Kotlin 1.0, we need to use `async () {...}` instead of `async {...}`.
This pull request fix wrong code snipet in doc/ADVANCED.

see https://blog.jetbrains.com/kotlin/2015/12/kotlin-1-0-beta-4-is-out/
