### PR TITLE
make background drawable nullable

### DIFF
--- a/dsl/static/src/platform/CustomViewProperties.kt
+++ b/dsl/static/src/platform/CustomViewProperties.kt
@@ -22,7 +22,7 @@ import android.view.View
 import android.widget.ImageView
 import android.widget.TextView
 
-var View.backgroundDrawable: Drawable
+var View.backgroundDrawable: Drawable?
     get() = background
     set(value) = setBackgroundDrawable(value)
 


### PR DESCRIPTION
background drawable's type is deceptive - this can blow up at any moment and the setter is too restrictive