### PR TITLE
Allow the database to be pluggable for query builders

### DIFF
--- a/anko/library/static/sqlite/src/Database.kt
+++ b/anko/library/static/sqlite/src/Database.kt
@@ -56,17 +56,17 @@ fun SQLiteDatabase.transaction(code: SQLiteDatabase.() -> Unit) {
 }
 
 fun SQLiteDatabase.select(tableName: String): SelectQueryBuilder {
-    return SelectQueryBuilder(this, tableName)
+    return AndroidSdkDatabaseSelectQueryBuilder(this, tableName)
 }
 
 fun SQLiteDatabase.select(tableName: String, vararg columns: String): SelectQueryBuilder {
-    val builder = SelectQueryBuilder(this, tableName)
+    val builder = AndroidSdkDatabaseSelectQueryBuilder(this, tableName)
     builder.columns(*columns)
     return builder
 }
 
 fun SQLiteDatabase.update(tableName: String, vararg values: Pair<String, Any?>): UpdateQueryBuilder {
-    return UpdateQueryBuilder(this, tableName, values)
+    return AndroidSdkDatabaseUpdateQueryBuilder(this, tableName, values)
 }
 
 fun SQLiteDatabase.delete(tableName: String, whereClause: String = "", vararg args: Pair<String, Any>): Int {

--- a/anko/library/static/sqlite/src/UpdateQueryBuilder.kt
+++ b/anko/library/static/sqlite/src/UpdateQueryBuilder.kt
@@ -16,11 +16,11 @@
 
 package org.jetbrains.anko.db
 
+import android.content.ContentValues
 import android.database.sqlite.SQLiteDatabase
 import org.jetbrains.anko.AnkoException
 
-class UpdateQueryBuilder(
-        val db: SQLiteDatabase,
+abstract class UpdateQueryBuilder(
         val tableName: String,
         val values: Array<out Pair<String, Any?>>
 ) {
@@ -74,6 +74,29 @@ class UpdateQueryBuilder(
     fun exec(): Int {
         val finalSelection = if (selectionApplied) selection else null
         val finalSelectionArgs = if (selectionApplied && useNativeSelection) nativeSelectionArgs else null
-        return db.update(tableName, values.toContentValues(), finalSelection, finalSelectionArgs)
+        return execUpdate(tableName, values.toContentValues(), finalSelection, finalSelectionArgs)
     }
+
+    abstract fun execUpdate(
+            table: String,
+            values: ContentValues,
+            whereClause: String?,
+            whereArgs: Array<out String>?
+    ): Int
+
+}
+
+class AndroidSdkDatabaseUpdateQueryBuilder(
+        private val db: SQLiteDatabase,
+        table: String,
+        values: Array<out Pair<String, Any?>>
+) : UpdateQueryBuilder(table, values) {
+
+    override fun execUpdate(
+            table: String,
+            values: ContentValues,
+            whereClause: String?,
+            whereArgs: Array<out String>?
+    ) = db.update(table, values, whereClause, whereArgs)
+
 }


### PR DESCRIPTION
This gives the ability to use SelectQueryBuilder and UpdateQueryBuilder with the org.sqlite.database API (or anything
else that can derive a Cursor from the information contained in the builders really) if desired.
The default is still to use the SQLiteDatabase bundled with the Android SDK.

Fixes #170