### PR TITLE
Update SQLITE.md to include Gradle dependency

### DIFF
--- a/doc/SQLITE.md
+++ b/doc/SQLITE.md
@@ -18,6 +18,15 @@ Anko provides lots of extension functions to simplify communication with SQLite 
 * [Updating values](#updating-values)
 * [Transactions](#transactions)
 
+
+## Gradle installation
+
+Add the following to your `build.gradle`:
+
+```groovy
+compile 'org.jetbrains.anko:anko-sqlite:0.8.3'
+```
+
 ## Db package
 
 All database-related tools are in the `org.jetbrains.anko.db` package. You could probably want to import all children at once:


### PR DESCRIPTION
Since the sqlite helpers were moved out of the main Anko package with 0.8.1, I think the Gradle installation steps should be detailed in this README.