### PR TITLE
Allow ManagedSQLiteOpenHelper to accept null for database name

### DIFF
--- a/anko/library/static/sqlite/src/Database.kt
+++ b/anko/library/static/sqlite/src/Database.kt
@@ -143,7 +143,7 @@ internal fun Array<out Pair<String, Any?>>.toContentValues(): ContentValues {
 
 abstract class ManagedSQLiteOpenHelper(
     ctx: Context,
-    name: String,
+    name: String?,
     factory: SQLiteDatabase.CursorFactory? = null,
     version: Int = 1
 ): SQLiteOpenHelper(ctx, name, factory, version) {


### PR DESCRIPTION
Nullable database name should be accepted in ```ManagedSQLiteOpenHelper ``` for in-memory database.