### PR TITLE
Uses valid jcenter repos in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,9 +144,9 @@ Basically, all you have to do is to add an additional repository and a compile d
 
 ```gradle
 dependencies {
-    compile 'org.jetbrains.anko:anko-sdk15:0.9.1' // sdk19, sdk21, sdk23 are also available
-    compile 'org.jetbrains.anko:anko-support-v4:0.9.1' // In case you need support-v4 bindings
-    compile 'org.jetbrains.anko:anko-appcompat-v7:0.9.1' // For appcompat-v7 bindings
+    compile 'org.jetbrains.anko:anko-sdk15:0.9' // sdk19, sdk21, sdk23 are also available
+    compile 'org.jetbrains.anko:anko-support-v4:0.9' // In case you need support-v4 bindings
+    compile 'org.jetbrains.anko:anko-appcompat-v7:0.9' // For appcompat-v7 bindings
 }
 ```
 


### PR DESCRIPTION
0.9.1 -> 0.9
When copying `0.9.1` from the README (which should be plug and play), I realized this was not on jcenter, which slows down development until one realizes that `0.9` is there.