### PR TITLE
Fix for an Anko build error.

### DIFF
--- a/anko/idea-plugin/xml-converter/test/org/jetbrains/kotlin/android/xmlconverter/BaseXmlConverterTest.java
+++ b/anko/idea-plugin/xml-converter/test/org/jetbrains/kotlin/android/xmlconverter/BaseXmlConverterTest.java
@@ -3,7 +3,6 @@ package org.jetbrains.kotlin.android.xmlconverter;
 import kotlin.text.Charsets;
 import org.junit.Rule;
 import org.junit.rules.TestName;
-import sun.plugin.dom.exception.InvalidStateException;
 import java.io.File;
 
 import static kotlin.collections.SetsKt.*;
@@ -20,7 +19,7 @@ public class BaseXmlConverterTest {
         File testDataDir = new File("xml-converter/testData");
         String testName = name.getMethodName();
         if (!testName.startsWith("test")) {
-            throw new InvalidStateException("Test name must start with a 'test' preffix");
+            throw new IllegalStateException("Test name must start with a 'test' preffix");
         }
 
         File testDir = new File(testDataDir, decapitalize(testName.substring("test".length())));

--- a/anko/library/generator/src/org/jetbrains/android/anko/sources/sourceProviders.kt
+++ b/anko/library/generator/src/org/jetbrains/android/anko/sources/sourceProviders.kt
@@ -19,7 +19,6 @@ package org.jetbrains.android.anko.sources
 import com.github.javaparser.JavaParser
 import com.github.javaparser.ast.CompilationUnit
 import org.jetbrains.android.anko.utils.getPackageName
-import sun.plugin.dom.exception.InvalidStateException
 import java.io.File
 
 interface SourceProvider {
@@ -31,9 +30,9 @@ class AndroidHomeSourceProvider(version: Int) : SourceProvider {
 
     init {
         val androidHome = System.getenv("ANDROID_HOME")
-                ?: throw InvalidStateException("ANDROID_HOME environment variable is not defined")
+                ?: throw IllegalStateException("ANDROID_HOME environment variable is not defined")
         baseDir = File(androidHome, "sources/android-$version")
-        if (!baseDir.exists()) throw InvalidStateException("${baseDir.absolutePath} does not exist")
+        if (!baseDir.exists()) throw IllegalStateException("${baseDir.absolutePath} does not exist")
     }
 
     override fun parse(fqName: String): CompilationUnit? {


### PR DESCRIPTION
A fresh checkout of Anko from master does not currently build.

Anko makes (gratuitous?) use of a sun.plugin.dom InvalidStateException.
The required java-plugin.jar is not fetched from update_dependencies.xml,
nor is it downloaded when doing a gradle build.

It does not seem like the jar is used anywhere else, so I figured removing the
dependency makes more sense than trying to get the dependency working.