### PR TITLE
Fix failing build, replacing ant-contrib dependency link

### DIFF
--- a/update_dependencies.xml
+++ b/update_dependencies.xml
@@ -18,16 +18,8 @@
         <get src="https://plugins.jetbrains.com/files/6954/28547/kotlin-plugin-1.0.4-release-IJ2016.1-112.zip"
              dest="dependencies/kotlin-plugin.zip" usetimestamp="true"/>
 
-        <get src="http://heanet.dl.sourceforge.net/project/ant-contrib/ant-contrib/1.0b3/ant-contrib-1.0b3-bin.zip"
-             dest="dependencies/download/ant-contrib-1.0b3-bin.zip" usetimestamp="true"/>
-
-        <delete file="dependencies/ant-contrib.jar" failonerror="false"/>
-        <unzip src="dependencies/download/ant-contrib-1.0b3-bin.zip" dest="dependencies">
-            <patternset>
-                <include name="ant-contrib/ant-contrib-1.0b3.jar"/>
-            </patternset>
-            <mapper type="merge" to="ant-contrib.jar"/>
-        </unzip>
+	<get src="http://repo1.maven.org/maven2/ant-contrib/ant-contrib/1.0b3/ant-contrib-1.0b3.jar"
+             dest="dependencies/ant-contrib.jar" usetimestamp="true"/>
 
         <delete dir="dependencies/kotlin-plugin" failonerror="false"/>
         <unzip src="dependencies/kotlin-plugin.zip"


### PR DESCRIPTION
Replace the old sourceforge link to ant-contrib with a maven link.  Additionally, since the dependency is now fetched as a jar instead of a zip, remove the step which unzipped it to the proper location.