### PR TITLE
Fixes failing xml-converter tests

### DIFF
--- a/anko/idea-plugin/xml-converter/src/org/jetbrains/kotlin/android/xmlconverter/Util.kt
+++ b/anko/idea-plugin/xml-converter/src/org/jetbrains/kotlin/android/xmlconverter/Util.kt
@@ -23,9 +23,9 @@ import org.jetbrains.kotlin.android.attrs.readResource
 
 private val INTENT = "    "
 
-internal val attrs = Gson().fromJson(readResource("attrs.json"), Attrs::class.java)
+internal val attrs = Gson().fromJson(readResource("../attrs.json"), Attrs::class.java)
 
-internal val viewHierarchy = Gson().fromJson<Map<String, List<String>>>(readResource("views.json"),
+internal val viewHierarchy = Gson().fromJson<Map<String, List<String>>>(readResource("../views.json"),
         (object : TypeToken<Map<String, List<String>>>() {}).type)
 
 internal data class KeyValuePair(val key: String, val value: String) {

--- a/anko/idea-plugin/xml-converter/test/org/jetbrains/kotlin/android/xmlconverter/BaseXmlConverterTest.java
+++ b/anko/idea-plugin/xml-converter/test/org/jetbrains/kotlin/android/xmlconverter/BaseXmlConverterTest.java
@@ -1,14 +1,15 @@
 package org.jetbrains.kotlin.android.xmlconverter;
 
+import static kotlin.collections.SetsKt.setOf;
+import static kotlin.io.FilesKt.readText;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+
 import kotlin.text.Charsets;
 import org.junit.Rule;
 import org.junit.rules.TestName;
-import java.io.File;
-
-import static kotlin.collections.SetsKt.*;
-import static kotlin.io.FilesKt.*;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 public class BaseXmlConverterTest {
 
@@ -16,7 +17,7 @@ public class BaseXmlConverterTest {
     public TestName name = new TestName();
 
     protected void doLayoutTest() {
-        File testDataDir = new File("xml-converter/testData");
+        File testDataDir = new File("testData");
         String testName = name.getMethodName();
         if (!testName.startsWith("test")) {
             throw new IllegalStateException("Test name must start with a 'test' preffix");


### PR DESCRIPTION
This fixes #331. There were 5 failing xml-converter tests, due to an invalid path to the attrs.json and views.json files.