### PR TITLE
Add `build()` function

### DIFF
--- a/anko/library/static/common/src/dialogs/AlertDialogBuilder.kt
+++ b/anko/library/static/common/src/dialogs/AlertDialogBuilder.kt
@@ -71,7 +71,7 @@ class AlertDialogBuilder(val ctx: Context) {
         checkBuilder()
         dialog = builder!!.create()
         builder = null
-        return dialog
+        return dialog!!
     }
 
     /**

--- a/anko/library/static/common/src/dialogs/AlertDialogBuilder.kt
+++ b/anko/library/static/common/src/dialogs/AlertDialogBuilder.kt
@@ -62,6 +62,17 @@ class AlertDialogBuilder(val ctx: Context) {
         dialog!!.show()
         return this
     }
+    
+    /**
+     * Build the [AlertDialog] 
+     *
+     */
+    fun build(): AlertDialog {
+        checkBuilder()
+        dialog = builder!!.create()
+        builder = null
+        return dialog
+    }
 
     /**
      * Set the [title] displayed in the dialog.


### PR DESCRIPTION
It's necessary, when you want to build dialog with DSL without showing it
For example, when extending `DialogFragment`

```
override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
        return ctx.alert { customView{\*...*\} }.build()
}
```