### PR TITLE
Made matchParent and wrapContent `const`s so they could be inlined.

### DIFF
--- a/anko/library/static/platform/src/CustomLayoutProperties.kt
+++ b/anko/library/static/platform/src/CustomLayoutProperties.kt
@@ -19,8 +19,8 @@ package org.jetbrains.anko
 
 import android.view.ViewGroup
 
-val matchParent: Int = android.view.ViewGroup.LayoutParams.MATCH_PARENT
-val wrapContent: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT
+const val matchParent: Int = android.view.ViewGroup.LayoutParams.MATCH_PARENT
+const val wrapContent: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT
 
 var ViewGroup.MarginLayoutParams.verticalMargin: Int
     get() = throw AnkoException("'ViewGroup.MarginLayoutParams.verticalMargin' property does not have a getter")


### PR DESCRIPTION
[Kotlin 1.1 has constant inlining](http://kotlinlang.org/docs/reference/whatsnew11.html#constant-inlining), and these two constants I marked with `const` modifier are the most frequentry used in Anko DSL.