### PR TITLE
Replace activity with context in Fragment.ctx

### DIFF
--- a/anko/library/static/common/src/ContextUtils.kt
+++ b/anko/library/static/common/src/ContextUtils.kt
@@ -51,7 +51,7 @@ inline val Fragment.act: Activity
     get() = activity
 
 inline val Fragment.ctx: Context
-    get() = activity
+    get() = context
 
 inline val Context.ctx: Context
     get() = this


### PR DESCRIPTION
I found `Fragment.ctx` returns `activity` instead of `context`. I think returning `context` is more contextual than returning `activity` :D