### PR TITLE
Change non-nullable Fragment.act/ctx to nullable

### DIFF
--- a/anko/library/static/commons/src/ContextUtils.kt
+++ b/anko/library/static/commons/src/ContextUtils.kt
@@ -47,10 +47,10 @@ inline val Context.defaultSharedPreferences: SharedPreferences
 inline val Fragment.defaultSharedPreferences: SharedPreferences
     get() = PreferenceManager.getDefaultSharedPreferences(activity)
 
-inline val Fragment.act: Activity
+inline val Fragment.act: Activity?
     get() = activity
 
-inline val Fragment.ctx: Context
+inline val Fragment.ctx: Context?
     get() = activity
 
 inline val Context.ctx: Context

--- a/anko/library/static/supportV4/src/SupportContextUtils.kt
+++ b/anko/library/static/supportV4/src/SupportContextUtils.kt
@@ -26,8 +26,8 @@ import android.support.v4.app.Fragment
 inline val Fragment.defaultSharedPreferences: SharedPreferences
     get() = PreferenceManager.getDefaultSharedPreferences(activity)
 
-inline val Fragment.act: Activity
+inline val Fragment.act: Activity?
     get() = activity
 
-inline val Fragment.ctx: Context
+inline val Fragment.ctx: Context?
     get() = activity


### PR DESCRIPTION
Hello, I found `Fragment.act` and `Fragment.ctx` returns `FragmentActivity` by calling `getActivity()`. 

But, `getActivity()` can return null when `mHost` is null.

```java
final public FragmentActivity getActivity() {
    return mHost == null ? null : (FragmentActivity) mHost.getActivity();
}
```

So, I changed `Fragment.act` and `Fragment.ctx` return type to nullable :D