### PR TITLE
Allow nullable values in `bundleOf` and `withArguments`

### DIFF
--- a/anko/library/robolectricTests/src/test/java/BundleOfTest.kt
+++ b/anko/library/robolectricTests/src/test/java/BundleOfTest.kt
@@ -1,0 +1,32 @@
+package test
+
+import org.jetbrains.anko.bundleOf
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricGradleTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricGradleTestRunner::class)
+@Config(constants = BuildConfig::class)
+class BundleOfTest {
+
+    @Test
+    fun test() {
+        val bundle1 = bundleOf()
+        assert(bundle1.isEmpty)
+
+        val bundle2 = bundleOf(
+            "one" to 1,
+            "abc" to "ABC",
+            "null" to null
+        )
+
+        assert(bundle2.size() == 3)
+        assert(bundle2.get("one") == 1)
+        assert(bundle2.get("abc") == "ABC")
+        assert(bundle2.get("null") == null)
+
+        println("[COMPLETE]")
+    }
+
+}

--- a/anko/library/robolectricTests/src/test/java/WithArgumentsTest.kt
+++ b/anko/library/robolectricTests/src/test/java/WithArgumentsTest.kt
@@ -1,0 +1,34 @@
+package test
+
+import android.app.Fragment
+import org.jetbrains.anko.withArguments
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricGradleTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricGradleTestRunner::class)
+@Config(constants = BuildConfig::class)
+class WithArgumentsTest {
+
+    @Test
+    fun test() {
+        val fragment1 = Fragment().withArguments()
+        assert(fragment1.arguments.isEmpty)
+
+        val fragment2 = Fragment().withArguments(
+            "one" to 1,
+            "abc" to "ABC",
+            "null" to null
+        )
+
+        val arguments = fragment2.arguments
+        assert(arguments.size() == 3)
+        assert(arguments.get("one") == 1)
+        assert(arguments.get("abc") == "ABC")
+        assert(arguments.get("null") == null)
+
+        println("[COMPLETE]")
+    }
+
+}

--- a/anko/library/static/commons/src/ContextUtils.kt
+++ b/anko/library/static/commons/src/ContextUtils.kt
@@ -75,16 +75,17 @@ inline fun <reified T : View> Activity.findOptional(@IdRes id: Int): T? = findVi
 inline fun <reified T : View> Fragment.findOptional(@IdRes id: Int): T? = view?.findViewById(id) as? T
 inline fun <reified T : View> Dialog.findOptional(@IdRes id: Int): T? = findViewById(id) as? T
 
-inline fun <T: Fragment> T.withArguments(vararg params: Pair<String, Any>): T {
+inline fun <T: Fragment> T.withArguments(vararg params: Pair<String, Any?>): T {
     arguments = bundleOf(*params)
     return this
 }
 
-fun bundleOf(vararg params: Pair<String, Any>): Bundle {
+fun bundleOf(vararg params: Pair<String, Any?>): Bundle {
     val b = Bundle()
     for (p in params) {
         val (k, v) = p
         when (v) {
+            null -> b.putSerializable(k, null)
             is Boolean -> b.putBoolean(k, v)
             is Byte -> b.putByte(k, v)
             is Char -> b.putChar(k, v)

--- a/anko/library/static/supportV4/src/Support.kt
+++ b/anko/library/static/supportV4/src/Support.kt
@@ -50,8 +50,8 @@ inline fun <T: Any> Fragment.configuration(
     else null
 }
 
-fun <T: Fragment> T.withArguments(vararg params: Pair<String, Any>): T {
-    setArguments(bundleOf(*params))
+fun <T: Fragment> T.withArguments(vararg params: Pair<String, Any?>): T {
+    arguments = bundleOf(*params)
     return this
 }
 


### PR DESCRIPTION
Resolves #375 

To match #211, bundleOf and withArguments should also allow null values.