### PR TITLE
childrenRecursiveSequence: fix NoSuchElementException being thrown when hasNext() returned true

### DIFF
--- a/anko/library/robolectricTests/src/test/java/ChildrenSequenceTest.kt
+++ b/anko/library/robolectricTests/src/test/java/ChildrenSequenceTest.kt
@@ -1,0 +1,70 @@
+package test
+
+import android.app.Activity
+import android.os.Bundle
+import android.widget.LinearLayout
+import android.widget.RelativeLayout
+import android.widget.TextView
+import org.jetbrains.anko.*
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricGradleTestRunner
+import org.robolectric.annotation.Config
+
+open class ChildrenSequenceTestActivity: Activity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        verticalLayout {
+            id = 1
+
+            relativeLayout {
+                id = 2
+                textView {
+                    id = 3
+                }
+                textView {
+                    id = 4
+                }
+                relativeLayout {
+                    id = 5
+                    textView {
+                        id = 6
+                    }
+                }
+            }
+            textView {
+                id = 7
+            }
+        }
+    }
+}
+
+@RunWith(RobolectricGradleTestRunner::class)
+@Config(constants = BuildConfig::class) class ChildrenSequenceTest {
+    @Test fun testChildrenSequence() {
+        val activity = Robolectric.buildActivity(ChildrenSequenceTestActivity::class.java).create().get()
+
+        val verticalLayout = activity.findViewById(1) as LinearLayout
+        val relativeLayout = activity.findViewById(2) as RelativeLayout
+        val textView = activity.findViewById(3) as TextView
+
+        assertEquals(listOf(2, 7), verticalLayout.childrenSequence().map { it.id }.toList())
+        assertEquals(listOf(3, 4, 5), relativeLayout.childrenSequence().map { it.id }.toList())
+        assert(textView.childrenSequence().toList().isEmpty())
+    }
+
+    @Test fun testChildrenRecursiveSequence() {
+        val activity = Robolectric.buildActivity(ChildrenSequenceTestActivity::class.java).create().get()
+
+        val verticalLayout = activity.findViewById(1) as LinearLayout
+        val relativeLayout = activity.findViewById(2) as RelativeLayout
+        val textView = activity.findViewById(3) as TextView
+
+        assertEquals(listOf(2, 7, 3, 4, 5, 6), verticalLayout.childrenRecursiveSequence().map { it.id }.toList())
+        assertEquals(listOf(3, 4, 5, 6), relativeLayout.childrenRecursiveSequence().map { it.id }.toList())
+        assert(textView.childrenRecursiveSequence().toList().isEmpty())
+    }
+}


### PR DESCRIPTION
This change addresses a problem caused by ViewChildrenRecursiveSequence's iterator `next` and `hasNext` both calling `initItemIterator`.

After `hasNext` returns `true` `itemIterator` is not `null`, therefore the condition
`iterator == null || (!iterator.hasNext() && seqs.isNotEmpty())`
in `initItemIterator` is equivalent to
`!iterator.hasNext() && seqs.isNotEmpty()`
which is `false` because `iterator.hasNext()` is `true`.

So `initItemIterator` in `next()` sets `itemIterator` to `null`, causing a `NoSuchElementException` to be thrown.

A test for the `childrenSequence()` and `childrenRecursiveSequence()` functions has been included.