### PR TITLE
Fix a typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ dependencies {
 
     // Coroutine listeners for Anko Layouts
     compile "org.jetbrains.anko:anko-sdk25-coroutines:$anko_version"
-    compile "org.jetbrains.anko:anko-appcompat-v7-couroutines:$anko_version"
+    compile "org.jetbrains.anko:anko-appcompat-v7-coroutines:$anko_version"
 
     // Anko SQLite
     compile "org.jetbrains.anko:anko-sqlite:$anko_version"


### PR DESCRIPTION
Trying to add the coroutines module would result in a gradle error