### PR TITLE
Added more text watcher listeners

### DIFF
--- a/anko/library/generated/sdk15-coroutines/src/ListenersWithCoroutines.kt
+++ b/anko/library/generated/sdk15-coroutines/src/ListenersWithCoroutines.kt
@@ -70,6 +70,18 @@ class __View_OnAttachStateChangeListener(private val context: CoroutineContext) 
     addTextChangedListener(listener)
 }
 
+fun android.widget.TextView.beforeTextChanged(context: CoroutineContext = UI, listener: suspend CoroutineScope.(CharSequence?, Int, Int, Int) -> Unit) {
+    textChangedListener(context) { beforeTextChanged(listener) }
+}
+
+fun android.widget.TextView.onTextChanged(context: CoroutineContext = UI, listener: suspend CoroutineScope.(CharSequence?, Int, Int, Int) -> Unit) {
+    textChangedListener(context) { onTextChanged(listener) }
+}
+
+fun android.widget.TextView.afterTextChanged(context: CoroutineContext = UI, listener: suspend CoroutineScope.(android.text.Editable?) -> Unit) {
+    textChangedListener(context) { afterTextChanged(listener) }
+}
+
 class __TextWatcher(private val context: CoroutineContext) : android.text.TextWatcher {
 
     private var _beforeTextChanged: (suspend CoroutineScope.(CharSequence?, Int, Int, Int) -> Unit)? = null

--- a/anko/library/generated/sdk15-listeners/src/Listeners.kt
+++ b/anko/library/generated/sdk15-listeners/src/Listeners.kt
@@ -42,6 +42,12 @@ fun android.widget.TextView.textChangedListener(init: __TextWatcher.() -> Unit) 
     addTextChangedListener(listener)
 }
 
+fun android.widget.TextView.beforeTextChanged(listener: (CharSequence?, Int, Int, Int) -> Unit) = textChangedListener { beforeTextChanged(listener) }
+
+fun android.widget.TextView.onTextChanged(listener: (CharSequence?, Int, Int, Int) -> Unit) = textChangedListener { onTextChanged(listener) }
+
+fun android.widget.TextView.afterTextChanged(listener: (android.text.Editable?) -> Unit) = textChangedListener { afterTextChanged(listener) }
+
 class __TextWatcher : android.text.TextWatcher {
 
     private var _beforeTextChanged: ((CharSequence?, Int, Int, Int) -> Unit)? = null

--- a/anko/library/generated/sdk19-coroutines/src/ListenersWithCoroutines.kt
+++ b/anko/library/generated/sdk19-coroutines/src/ListenersWithCoroutines.kt
@@ -70,6 +70,18 @@ class __View_OnAttachStateChangeListener(private val context: CoroutineContext) 
     addTextChangedListener(listener)
 }
 
+fun android.widget.TextView.beforeTextChanged(context: CoroutineContext = UI, listener: suspend CoroutineScope.(CharSequence?, Int, Int, Int) -> Unit) {
+    textChangedListener(context) { beforeTextChanged(listener) }
+}
+
+fun android.widget.TextView.onTextChanged(context: CoroutineContext = UI, listener: suspend CoroutineScope.(CharSequence?, Int, Int, Int) -> Unit) {
+    textChangedListener(context) { onTextChanged(listener) }
+}
+
+fun android.widget.TextView.afterTextChanged(context: CoroutineContext = UI, listener: suspend CoroutineScope.(android.text.Editable?) -> Unit) {
+    textChangedListener(context) { afterTextChanged(listener) }
+}
+
 class __TextWatcher(private val context: CoroutineContext) : android.text.TextWatcher {
 
     private var _beforeTextChanged: (suspend CoroutineScope.(CharSequence?, Int, Int, Int) -> Unit)? = null

--- a/anko/library/generated/sdk19-listeners/src/Listeners.kt
+++ b/anko/library/generated/sdk19-listeners/src/Listeners.kt
@@ -42,6 +42,12 @@ fun android.widget.TextView.textChangedListener(init: __TextWatcher.() -> Unit) 
     addTextChangedListener(listener)
 }
 
+fun android.widget.TextView.beforeTextChanged(listener: (CharSequence?, Int, Int, Int) -> Unit) = textChangedListener { beforeTextChanged(listener) }
+
+fun android.widget.TextView.onTextChanged(listener: (CharSequence?, Int, Int, Int) -> Unit) = textChangedListener { onTextChanged(listener) }
+
+fun android.widget.TextView.afterTextChanged(listener: (android.text.Editable?) -> Unit) = textChangedListener { afterTextChanged(listener) }
+
 class __TextWatcher : android.text.TextWatcher {
 
     private var _beforeTextChanged: ((CharSequence?, Int, Int, Int) -> Unit)? = null

--- a/anko/library/generated/sdk21-coroutines/src/ListenersWithCoroutines.kt
+++ b/anko/library/generated/sdk21-coroutines/src/ListenersWithCoroutines.kt
@@ -71,6 +71,18 @@ class __View_OnAttachStateChangeListener(private val context: CoroutineContext) 
     addTextChangedListener(listener)
 }
 
+fun android.widget.TextView.beforeTextChanged(context: CoroutineContext = UI, listener: suspend CoroutineScope.(CharSequence?, Int, Int, Int) -> Unit) {
+    textChangedListener(context) { beforeTextChanged(listener) }
+}
+
+fun android.widget.TextView.onTextChanged(context: CoroutineContext = UI, listener: suspend CoroutineScope.(CharSequence?, Int, Int, Int) -> Unit) {
+    textChangedListener(context) { onTextChanged(listener) }
+}
+
+fun android.widget.TextView.afterTextChanged(context: CoroutineContext = UI, listener: suspend CoroutineScope.(android.text.Editable?) -> Unit) {
+    textChangedListener(context) { afterTextChanged(listener) }
+}
+
 class __TextWatcher(private val context: CoroutineContext) : android.text.TextWatcher {
 
     private var _beforeTextChanged: (suspend CoroutineScope.(CharSequence?, Int, Int, Int) -> Unit)? = null

--- a/anko/library/generated/sdk21-listeners/src/Listeners.kt
+++ b/anko/library/generated/sdk21-listeners/src/Listeners.kt
@@ -42,6 +42,12 @@ fun android.widget.TextView.textChangedListener(init: __TextWatcher.() -> Unit) 
     addTextChangedListener(listener)
 }
 
+fun android.widget.TextView.beforeTextChanged(listener: (CharSequence?, Int, Int, Int) -> Unit) = textChangedListener { beforeTextChanged(listener) }
+
+fun android.widget.TextView.onTextChanged(listener: (CharSequence?, Int, Int, Int) -> Unit) = textChangedListener { onTextChanged(listener) }
+
+fun android.widget.TextView.afterTextChanged(listener: (android.text.Editable?) -> Unit) = textChangedListener { afterTextChanged(listener) }
+
 class __TextWatcher : android.text.TextWatcher {
 
     private var _beforeTextChanged: ((CharSequence?, Int, Int, Int) -> Unit)? = null

--- a/anko/library/generated/sdk23-coroutines/src/ListenersWithCoroutines.kt
+++ b/anko/library/generated/sdk23-coroutines/src/ListenersWithCoroutines.kt
@@ -71,6 +71,18 @@ class __View_OnAttachStateChangeListener(private val context: CoroutineContext) 
     addTextChangedListener(listener)
 }
 
+fun android.widget.TextView.beforeTextChanged(context: CoroutineContext = UI, listener: suspend CoroutineScope.(CharSequence?, Int, Int, Int) -> Unit) {
+    textChangedListener(context) { beforeTextChanged(listener) }
+}
+
+fun android.widget.TextView.onTextChanged(context: CoroutineContext = UI, listener: suspend CoroutineScope.(CharSequence?, Int, Int, Int) -> Unit) {
+    textChangedListener(context) { onTextChanged(listener) }
+}
+
+fun android.widget.TextView.afterTextChanged(context: CoroutineContext = UI, listener: suspend CoroutineScope.(android.text.Editable?) -> Unit) {
+    textChangedListener(context) { afterTextChanged(listener) }
+}
+
 class __TextWatcher(private val context: CoroutineContext) : android.text.TextWatcher {
 
     private var _beforeTextChanged: (suspend CoroutineScope.(CharSequence?, Int, Int, Int) -> Unit)? = null

--- a/anko/library/generated/sdk23-listeners/src/Listeners.kt
+++ b/anko/library/generated/sdk23-listeners/src/Listeners.kt
@@ -42,6 +42,12 @@ fun android.widget.TextView.textChangedListener(init: __TextWatcher.() -> Unit) 
     addTextChangedListener(listener)
 }
 
+fun android.widget.TextView.beforeTextChanged(listener: (CharSequence?, Int, Int, Int) -> Unit) = textChangedListener { beforeTextChanged(listener) }
+
+fun android.widget.TextView.onTextChanged(listener: (CharSequence?, Int, Int, Int) -> Unit) = textChangedListener { onTextChanged(listener) }
+
+fun android.widget.TextView.afterTextChanged(listener: (android.text.Editable?) -> Unit) = textChangedListener { afterTextChanged(listener) }
+
 class __TextWatcher : android.text.TextWatcher {
 
     private var _beforeTextChanged: ((CharSequence?, Int, Int, Int) -> Unit)? = null

--- a/anko/library/generated/sdk25-coroutines/src/ListenersWithCoroutines.kt
+++ b/anko/library/generated/sdk25-coroutines/src/ListenersWithCoroutines.kt
@@ -71,6 +71,18 @@ class __View_OnAttachStateChangeListener(private val context: CoroutineContext) 
     addTextChangedListener(listener)
 }
 
+fun android.widget.TextView.beforeTextChanged(context: CoroutineContext = UI, listener: suspend CoroutineScope.(CharSequence?, Int, Int, Int) -> Unit) {
+    textChangedListener(context) { beforeTextChanged(listener) }
+}
+
+fun android.widget.TextView.onTextChanged(context: CoroutineContext = UI, listener: suspend CoroutineScope.(CharSequence?, Int, Int, Int) -> Unit) {
+    textChangedListener(context) { onTextChanged(listener) }
+}
+
+fun android.widget.TextView.afterTextChanged(context: CoroutineContext = UI, listener: suspend CoroutineScope.(android.text.Editable?) -> Unit) {
+    textChangedListener(context) { afterTextChanged(listener) }
+}
+
 class __TextWatcher(private val context: CoroutineContext) : android.text.TextWatcher {
 
     private var _beforeTextChanged: (suspend CoroutineScope.(CharSequence?, Int, Int, Int) -> Unit)? = null

--- a/anko/library/generated/sdk25-listeners/src/Listeners.kt
+++ b/anko/library/generated/sdk25-listeners/src/Listeners.kt
@@ -42,6 +42,12 @@ fun android.widget.TextView.textChangedListener(init: __TextWatcher.() -> Unit) 
     addTextChangedListener(listener)
 }
 
+fun android.widget.TextView.beforeTextChanged(listener: (CharSequence?, Int, Int, Int) -> Unit) = textChangedListener { beforeTextChanged(listener) }
+
+fun android.widget.TextView.onTextChanged(listener: (CharSequence?, Int, Int, Int) -> Unit) = textChangedListener { onTextChanged(listener) }
+
+fun android.widget.TextView.afterTextChanged(listener: (android.text.Editable?) -> Unit) = textChangedListener { afterTextChanged(listener) }
+
 class __TextWatcher : android.text.TextWatcher {
 
     private var _beforeTextChanged: ((CharSequence?, Int, Int, Int) -> Unit)? = null


### PR DESCRIPTION
Hi, I thought it would be useful to have a shorter way to add a text changed listener to a `TextView` when only one of the methods `beforeTextChanged`, `onTextChanged` or `afterTextChanged` is used:

```kotlin
textView.beforeTextChanged { ... }
// instead of textView.textChangedListener { beforeTextChanged { ... } }

textView.onTextChanged { ... }
// instead of textView.textChangedListener { onTextChanged { ... } }

textView.afterTextChanged { ... }
// instead of textView.textChangedListener { afterTextChanged { ... } }
```