### PR TITLE
Added snackbar helpers with indefinite duration

### DIFF
--- a/anko/library/static/design/src/Snackbar.kt
+++ b/anko/library/static/design/src/Snackbar.kt
@@ -40,6 +40,15 @@ inline fun longSnackbar(view: View, message: Int) = Snackbar
         .apply { show() }
 
 /**
+ * Display Snackbar with the [Snackbar.LENGTH_INDEFINITE] duration.
+ *
+ * @param message the message text resource.
+ */
+inline fun indefiniteSnackbar(view: View, message: Int) = Snackbar
+        .make(view, message, Snackbar.LENGTH_INDEFINITE)
+        .apply { show() }
+
+/**
  * Display the Snackbar with the [Snackbar.LENGTH_SHORT] duration.
  *
  * @param message the message text.
@@ -55,6 +64,15 @@ inline fun snackbar(view: View, message: String) = Snackbar
  */
 inline fun longSnackbar(view: View, message: String) = Snackbar
         .make(view, message, Snackbar.LENGTH_LONG)
+        .apply { show() }
+
+/**
+ * Display Snackbar with the [Snackbar.LENGTH_INDEFINITE] duration.
+ *
+ * @param message the message text.
+ */
+inline fun indefiniteSnackbar(view: View, message: String) = Snackbar
+        .make(view, message, Snackbar.LENGTH_INDEFINITE)
         .apply { show() }
 
 /**
@@ -82,6 +100,18 @@ inline fun longSnackbar(view: View, message: Int, actionText: Int, noinline acti
         }
 
 /**
+ * Display Snackbar with the [Snackbar.LENGTH_INDEFINITE] duration.
+ *
+ * @param message the message text resource.
+ */
+inline fun indefiniteSnackbar(view: View, message: Int, actionText: Int, noinline action: (View) -> Unit) = Snackbar
+        .make(view, message, Snackbar.LENGTH_INDEFINITE)
+        .apply {
+            setAction(actionText, action)
+            show()
+        }
+
+/**
  * Display the Snackbar with the [Snackbar.LENGTH_SHORT] duration.
  *
  * @param message the message text.
@@ -100,6 +130,18 @@ inline fun snackbar(view: View, message: String, actionText: String, noinline ac
  */
 inline fun longSnackbar(view: View, message: String, actionText: String, noinline action: (View) -> Unit) = Snackbar
         .make(view, message, Snackbar.LENGTH_LONG)
+        .apply {
+            setAction(actionText, action)
+            show()
+        }
+
+/**
+ * Display Snackbar with the [Snackbar.LENGTH_INDEFINITE] duration.
+ *
+ * @param message the message text.
+ */
+inline fun indefiniteSnackbar(view: View, message: String, actionText: String, noinline action: (View) -> Unit) = Snackbar
+        .make(view, message, Snackbar.LENGTH_INDEFINITE)
         .apply {
             setAction(actionText, action)
             show()


### PR DESCRIPTION
As the title suggests, I added helper functions `indefiniteSnackbar` for creating snackbars with duration `Snackbar.LENGTH_INDEFINITE`. They work exactly like the other snackbar helpers.