### PR TITLE
Typo progressDialog

### DIFF
--- a/anko/library/static/commons/src/dialogs/AndroidDialogs.kt
+++ b/anko/library/static/commons/src/dialogs/AndroidDialogs.kt
@@ -112,7 +112,7 @@ inline fun Fragment.indeterminateProgressDialog(
         message: Int? = null,
         title: Int? = null,
         noinline init: (ProgressDialog.() -> Unit)? = null
-) = activity.progressDialog(message, title, init)
+) = activity.indeterminateProgressDialog(message, title, init)
 
 fun Context.indeterminateProgressDialog(
         message: Int? = null,


### PR DESCRIPTION
Fix typo that makes indeterminateProgressDialog to create a classic progressDialog