### PR TITLE
Return toast object in toast helper functions.

### DIFF
--- a/anko/library/static/commons/src/dialogs/Toasts.kt
+++ b/anko/library/static/commons/src/dialogs/Toasts.kt
@@ -40,7 +40,11 @@ inline fun Fragment.toast(message: Int) = activity.toast(message)
  *
  * @param message the message text resource.
  */
-fun Context.toast(message: Int) = Toast.makeText(this, message, Toast.LENGTH_SHORT).show()
+inline fun Context.toast(message: Int): Toast = Toast
+        .makeText(this, message, Toast.LENGTH_SHORT)
+        .apply {
+            show()
+        }
 
 /**
  * Display the simple Toast message with the [Toast.LENGTH_SHORT] duration.
@@ -61,7 +65,11 @@ inline fun Fragment.toast(message: CharSequence) = activity.toast(message)
  *
  * @param message the message text.
  */
-fun Context.toast(message: CharSequence) = Toast.makeText(this, message, Toast.LENGTH_SHORT).show()
+inline fun Context.toast(message: CharSequence): Toast = Toast
+        .makeText(this, message, Toast.LENGTH_SHORT)
+        .apply {
+            show()
+        }
 
 /**
  * Display the simple Toast message with the [Toast.LENGTH_LONG] duration.
@@ -82,7 +90,11 @@ inline fun Fragment.longToast(message: Int) = activity.longToast(message)
  *
  * @param message the message text resource.
  */
-inline fun Context.longToast(message: Int) = Toast.makeText(this, message, Toast.LENGTH_LONG).show()
+inline fun Context.longToast(message: Int): Toast = Toast
+        .makeText(this, message, Toast.LENGTH_LONG)
+        .apply {
+            show()
+        }
 
 /**
  * Display the simple Toast message with the [Toast.LENGTH_LONG] duration.
@@ -103,4 +115,8 @@ inline fun Fragment.longToast(message: CharSequence) = activity.longToast(messag
  *
  * @param message the message text.
  */
-inline fun Context.longToast(message: CharSequence) = Toast.makeText(this, message, Toast.LENGTH_LONG).show()
+inline fun Context.longToast(message: CharSequence): Toast = Toast
+        .makeText(this, message, Toast.LENGTH_LONG)
+        .apply {
+            show()
+        }

--- a/anko/library/static/supportV4/src/SupportDialogs.kt
+++ b/anko/library/static/supportV4/src/SupportDialogs.kt
@@ -22,13 +22,13 @@ import android.content.DialogInterface
 import android.support.v4.app.Fragment
 import org.jetbrains.anko.*
 
-inline fun Fragment.toast(textResource: Int): Unit = activity.toast(textResource)
+inline fun Fragment.toast(textResource: Int) = activity.toast(textResource)
 
-inline fun Fragment.toast(text: CharSequence): Unit = activity.toast(text)
+inline fun Fragment.toast(text: CharSequence) = activity.toast(text)
 
-inline fun Fragment.longToast(textResource: Int): Unit = activity.longToast(textResource)
+inline fun Fragment.longToast(textResource: Int) = activity.longToast(textResource)
 
-inline fun Fragment.longToast(text: CharSequence): Unit = activity.longToast(text)
+inline fun Fragment.longToast(text: CharSequence) = activity.longToast(text)
 
 inline fun Fragment.selector(
         title: CharSequence? = null,


### PR DESCRIPTION
The toast helper functions now return the Toast object so users can cancel if needed. Return types are explicitly specified because the platform toast functions are missing nullability annotations. This also fixes #504.