### PR TITLE
Update support fragment helpers

### DIFF
--- a/anko/library/static/supportV4/src/SupportIntents.kt
+++ b/anko/library/static/supportV4/src/SupportIntents.kt
@@ -33,19 +33,19 @@ fun Fragment.email(email: String, subject: String = "", text: String = ""): Bool
 
 fun Fragment.makeCall(number: String): Boolean = activity.makeCall(number)
 
-inline fun <reified T: Activity> Fragment.startActivity(vararg params: Pair<String, Any>) {
+inline fun <reified T: Activity> Fragment.startActivity(vararg params: Pair<String, Any?>) {
     AnkoInternals.internalStartActivity(activity, T::class.java, params)
 }
 
-inline fun <reified T: Activity> Fragment.startActivityForResult(requestCode: Int, vararg params: Pair<String, Any>) {
+inline fun <reified T: Activity> Fragment.startActivityForResult(requestCode: Int, vararg params: Pair<String, Any?>) {
     startActivityForResult(AnkoInternals.createIntent(act, T::class.java, params), requestCode)
 }
 
-inline fun <reified T: Service> Fragment.startService(vararg params: Pair<String, Any>) {
+inline fun <reified T: Service> Fragment.startService(vararg params: Pair<String, Any?>) {
     AnkoInternals.internalStartService(activity, T::class.java, params)
 }
 
-inline fun <reified T : Service> Fragment.stopService(vararg params: Pair<String, Any>) {
+inline fun <reified T : Service> Fragment.stopService(vararg params: Pair<String, Any?>) {
     AnkoInternals.internalStopService(activity, T::class.java, params)
 }
 

--- a/anko/library/static/supportV4/src/SupportIntents.kt
+++ b/anko/library/static/supportV4/src/SupportIntents.kt
@@ -33,6 +33,8 @@ fun Fragment.email(email: String, subject: String = "", text: String = ""): Bool
 
 fun Fragment.makeCall(number: String): Boolean = activity.makeCall(number)
 
+fun Fragment.sendSMS(number: String, text: String = ""): Boolean = activity.sendSMS(number, text)
+
 inline fun <reified T: Activity> Fragment.startActivity(vararg params: Pair<String, Any?>) {
     AnkoInternals.internalStartActivity(activity, T::class.java, params)
 }
@@ -49,4 +51,5 @@ inline fun <reified T : Service> Fragment.stopService(vararg params: Pair<String
     AnkoInternals.internalStopService(activity, T::class.java, params)
 }
 
-inline fun <reified T: Any> Fragment.intentFor(): Intent = Intent(activity, T::class.java)
+inline fun <reified T: Any> Fragment.intentFor(vararg params: Pair<String, Any?>): Intent =
+        AnkoInternals.createIntent(activity, T::class.java, params)


### PR DESCRIPTION
- Allow nullable values for support fragment intents. This was implemented for platform intent helpers in #465 but the support fragment intent helpers were left out.
- Add missing `sendSms` helper function for support library fragments.
- Allow `intentFor` helper for support library fragments to take intent parameters.