### PR TITLE
'compile' replaced with 'implementation'

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Anko has a meta-dependency which plugs in all available features (including Comm
 
 ```gradle
 dependencies {
-    compile "org.jetbrains.anko:anko:$anko_version"
+    implementation "org.jetbrains.anko:anko:$anko_version"
 }
 ```
 Make sure that you have the ```$anko_version``` settled in your gradle file at the project level:
@@ -90,18 +90,18 @@ If you only need some of the features, you can reference any of Anko's parts:
 ```gradle
 dependencies {
     // Anko Commons
-    compile "org.jetbrains.anko:anko-commons:$anko_version"
+    implementation "org.jetbrains.anko:anko-commons:$anko_version"
 
     // Anko Layouts
-    compile "org.jetbrains.anko:anko-sdk25:$anko_version" // sdk15, sdk19, sdk21, sdk23 are also available
-    compile "org.jetbrains.anko:anko-appcompat-v7:$anko_version"
+    implementation "org.jetbrains.anko:anko-sdk25:$anko_version" // sdk15, sdk19, sdk21, sdk23 are also available
+    implementation "org.jetbrains.anko:anko-appcompat-v7:$anko_version"
 
     // Coroutine listeners for Anko Layouts
-    compile "org.jetbrains.anko:anko-sdk25-coroutines:$anko_version"
-    compile "org.jetbrains.anko:anko-appcompat-v7-coroutines:$anko_version"
+    implementation "org.jetbrains.anko:anko-sdk25-coroutines:$anko_version"
+    implementation "org.jetbrains.anko:anko-appcompat-v7-coroutines:$anko_version"
 
     // Anko SQLite
-    compile "org.jetbrains.anko:anko-sqlite:$anko_version"
+    implementation "org.jetbrains.anko:anko-sqlite:$anko_version"
 }
 ```
 
@@ -110,37 +110,37 @@ There are also a number of artifacts for the Android support libraries:
 ```gradle
 dependencies {
     // Appcompat-v7 (only Anko Commons)
-    compile "org.jetbrains.anko:anko-appcompat-v7-commons:$anko_version"
+    implementation "org.jetbrains.anko:anko-appcompat-v7-commons:$anko_version"
 
     // Appcompat-v7 (Anko Layouts)
-    compile "org.jetbrains.anko:anko-appcompat-v7:$anko_version"
-    compile "org.jetbrains.anko:anko-coroutines:$anko_version"
+    implementation "org.jetbrains.anko:anko-appcompat-v7:$anko_version"
+    implementation "org.jetbrains.anko:anko-coroutines:$anko_version"
 
     // CardView-v7
-    compile "org.jetbrains.anko:anko-cardview-v7:$anko_version"
+    implementation "org.jetbrains.anko:anko-cardview-v7:$anko_version"
 
     // Design
-    compile "org.jetbrains.anko:anko-design:$anko_version"
-    compile "org.jetbrains.anko:anko-design-coroutines:$anko_version"
+    implementation "org.jetbrains.anko:anko-design:$anko_version"
+    implementation "org.jetbrains.anko:anko-design-coroutines:$anko_version"
 
     // GridLayout-v7
-    compile "org.jetbrains.anko:anko-gridlayout-v7:$anko_version"
+    implementation "org.jetbrains.anko:anko-gridlayout-v7:$anko_version"
 
     // Percent
-    compile "org.jetbrains.anko:anko-percent:$anko_version"
+    implementation "org.jetbrains.anko:anko-percent:$anko_version"
 
     // RecyclerView-v7
-    compile "org.jetbrains.anko:anko-recyclerview-v7:$anko_version"
-    compile "org.jetbrains.anko:anko-recyclerview-v7-coroutines:$anko_version"
+    implementation "org.jetbrains.anko:anko-recyclerview-v7:$anko_version"
+    implementation "org.jetbrains.anko:anko-recyclerview-v7-coroutines:$anko_version"
 
     // Support-v4 (only Anko Commons)
-    compile "org.jetbrains.anko:anko-support-v4-commons:$anko_version"
+    implementation "org.jetbrains.anko:anko-support-v4-commons:$anko_version"
 
     // Support-v4 (Anko Layouts)
-    compile "org.jetbrains.anko:anko-support-v4:$anko_version"
+    implementation "org.jetbrains.anko:anko-support-v4:$anko_version"
 
     // ConstraintLayout
-    compile "org.jetbrains.anko:anko-constraint-layout:$anko_version"
+    implementation "org.jetbrains.anko:anko-constraint-layout:$anko_version"
 }
 ```
 


### PR DESCRIPTION
Configuration 'compile' is obsolete and has been replaced with 'implementation'.
It will be removed at the end of 2018