### PR TITLE
Fix spelling of dimensionRation -> dimensionRatio (#671)

### DIFF
--- a/anko/library/static/constraint-layout/src/main/java/ConstraintLayout.kt
+++ b/anko/library/static/constraint-layout/src/main/java/ConstraintLayout.kt
@@ -72,7 +72,7 @@ class ViewConstraintBuilder(
             constraintSetBuilder.setVerticalBias(viewId, value)
         }
 
-    var dimensionRation: String
+    var dimensionRatio: String
         @Deprecated(AnkoInternals.NO_GETTER, level = DeprecationLevel.ERROR) get() = noGetter()
         set(value) {
             constraintSetBuilder.setDimensionRatio(viewId, value)


### PR DESCRIPTION
Summary: Looks like there was a typo here. This may be a breaking change (requires code change for users), but should be a simple and obvious fix for any users of the library. Fixes issue #671.

Test Plan: Looks like test coverage is minimal for this code, but `test` gradle task within the `anko-constraint-layout` project was run as well as the `test` task within the `robolectricTests` project.