### PR TITLE
[fix] Listener signature parsing with generics cause IllegalStateException

### DIFF
--- a/anko/library/generator/src/org/jetbrains/android/anko/render/ListenerRenderer.kt
+++ b/anko/library/generator/src/org/jetbrains/android/anko/render/ListenerRenderer.kt
@@ -43,10 +43,14 @@ abstract class AbstractListenerRenderer(context: GeneratorContext) : Renderer(co
 
     override fun processElements(state: GenerationState) = generatedFile { importList ->
         for (listener in state[ListenerGenerator::class.java]) {
-            when (listener) {
-                is SimpleListenerElement -> append(listener.render(importList))
-                is ComplexListenerElement -> append(listener.render(importList))
-                else -> throw RuntimeException("Invalid listener type: ${listener.javaClass.name}")
+            try {
+                when (listener) {
+                    is SimpleListenerElement -> append(listener.render(importList))
+                    is ComplexListenerElement -> append(listener.render(importList))
+                    else -> throw RuntimeException("Invalid listener type: ${listener.javaClass.name}")
+                }
+            } catch (e: IllegalStateException) {
+                state.context.logger.i("Skip ${listener.clazz.name} listener")
             }
         }
     }


### PR DESCRIPTION
Avoids listeners with generics like [AppBarLayout.BaseOnOffsetChangedListener](https://developer.android.com/reference/com/google/android/material/appbar/AppBarLayout.BaseOnOffsetChangedListener.html) in material desing library

Current signature parser could not properly process generics and throws 
 ``` java.lang.IllegalStateException: Invalid classifier type: TypeVariable(name=T) ```

After fix we will be skipping these listeners